### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/02-scheduled-exec.yaml
+++ b/.github/workflows/02-scheduled-exec.yaml
@@ -1,4 +1,6 @@
 name: 'Execução Manual'
+permissions:
+  contents: read
 
 on:
     schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/anaclaudiaaraujo/pgats-ci-lab/security/code-scanning/2](https://github.com/anaclaudiaaraujo/pgats-ci-lab/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code, installs dependencies, runs tests, and uploads artifacts (which does not require write access to repository contents), the minimal permission required is `contents: read`. This block should be added at the top level of the workflow file, just below the `name` field and before the `on` field, to apply to all jobs in the workflow. No changes to steps or jobs are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
