### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/01-manual-exec.yaml
+++ b/.github/workflows/01-manual-exec.yaml
@@ -1,4 +1,6 @@
 name: 'Execução Manual'
+permissions:
+  contents: read
 
 on:
     workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/anaclaudiaaraujo/pgats-ci-lab/security/code-scanning/1](https://github.com/anaclaudiaaraujo/pgats-ci-lab/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow or to the specific job. The minimal required permission for this workflow is `contents: read`, as none of the steps require write access to repository contents, issues, or pull requests. The best way to fix this is to add the following block at the top level of the workflow (just after the `name:` line and before `on:`), so it applies to all jobs in the workflow. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
